### PR TITLE
Only installs user demo report if demos are required

### DIFF
--- a/report_py3o/__manifest__.py
+++ b/report_py3o/__manifest__.py
@@ -23,6 +23,8 @@
         "security/ir.model.access.csv",
         "views/py3o_template.xml",
         "views/ir_actions_report.xml",
+    ],
+    "demo": [
         "demo/report_py3o.xml",
     ],
     "installable": True,


### PR DESCRIPTION
Puede ser que esto corrija el hecho de que sale un informe de demo aquí:

![image](https://github.com/user-attachments/assets/05fc442b-a555-431a-922e-1b915e9676e6)
